### PR TITLE
Fix Netlify API routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,11 @@ data-preparing-cline/
 4. Select your repository
 5. Configure the build settings:
    - Build command: `npm run build`
-   - Publish directory: `build`
+   - Publish directory: `dist`
 6. Click "Deploy site"
-7. Once deployed, go to Site settings > Functions > Settings and set the functions directory to `functions`
-8. Set up environment variables in Site settings > Build & deploy > Environment
+7. Once deployed, go to **Site settings → Functions → Settings** and set the functions directory to `functions`
+8. Set up environment variables in **Site settings → Build & deploy → Environment**
+9. All API calls should target paths starting with `/api` (e.g. `/api/upload`). Netlify redirects these calls to the `api` serverless function automatically.
 
 ### Local Deployment
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -12,7 +12,7 @@
 
 [[redirects]]
   from = "/api/*"
-  to = "/.netlify/functions/:splat"
+  to = "/.netlify/functions/api/:splat"
   status = 200
 
 [[redirects]]

--- a/src/frontend/config/api.js
+++ b/src/frontend/config/api.js
@@ -3,9 +3,9 @@
 const isDevelopment = process.env.NODE_ENV === 'development';
 
 // Base URL for API requests
-const API_BASE_URL = isDevelopment 
-  ? 'http://localhost:3000/api' 
-  : '/.netlify/functions/api';
+const API_BASE_URL = isDevelopment
+  ? 'http://localhost:3000/api'
+  : '/api';
 
 // API endpoints
 const API_ENDPOINTS = {


### PR DESCRIPTION
## Summary
- direct `/api/*` traffic to the `api` Netlify function
- update production API base URL
- document correct publish directory and API usage for Netlify deploys

## Testing
- `npm test` *(fails: Error: no test specified)*